### PR TITLE
If you've installed vagrant-cachier, then use it

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                     path: "vagrant-bootstrap.sh",
                     args: "localdev localdev"
       development.ssh.forward_agent = true
+      if Vagrant.has_plugin?('vagrant-cachier')
+        config.cache.auto_detect = true
+      end
     end
 
 #    config.vm.define "jenkins" do |jenkins|


### PR DESCRIPTION
You can install vagrant-cachier with vagrant plugin install vagrant-cachier.
If it's not installed nothing changes.
If it is installed the pip, rubygems and apt updates will be cached, making startup a bit faster.

This will break on older versions of Vagrant (prior to 1.3 I think) due to the new nature of Vagrant.has_plugin.
If you got a windows machine you should be up to date, but those people using older machines may need to upgrade.
